### PR TITLE
Install ocicl from .deb instead of building from source

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,12 @@ retry_command0() {
 git config --global http.version HTTP/1.1
 git config --global http.postBuffer 157286400
 
-(cd ~; retry_command0 git clone --depth=1 https://github.com/ocicl/ocicl.git; cd ocicl; sbcl --eval "(defconstant +dynamic-space-size+ 5000)" --load setup.lisp; ocicl version; ocicl setup > ~/.sbclrc)
+DEB_URL=$(curl -s https://api.github.com/repos/ocicl/ocicl/releases/latest \
+  | grep -o '"browser_download_url": *"[^"]*_amd64\.deb"' \
+  | grep -o 'https://[^"]*')
+retry_command0 curl -LO "$DEB_URL"
+dpkg -i ocicl_*_amd64.deb
+ocicl setup > ~/.sbclrc
 echo "(setf ocicl-runtime:*verbose* t)" >> ~/.sbclrc
 echo "(setf ocicl-runtime:*download* t)" >> ~/.sbclrc
 ~/bin/sbcl --non-interactive --eval "(quit)"


### PR DESCRIPTION
## Summary
- Replaces the git clone + build-from-source ocicl installation in `run.sh` with downloading the latest `.deb` package from GitHub releases
- Uses the GitHub API to resolve the latest release's `.deb` URL dynamically
- Significantly speeds up every package build since ocicl no longer needs to be compiled from scratch each time

## Change
Before:
```bash
(cd ~; git clone --depth=1 https://github.com/ocicl/ocicl.git; cd ocicl; sbcl --load setup.lisp; ocicl version; ocicl setup > ~/.sbclrc)
```

After:
```bash
DEB_URL=$(curl -s https://api.github.com/repos/ocicl/ocicl/releases/latest \
  | grep -o '"browser_download_url": *"[^"]*_amd64\.deb"' \
  | grep -o 'https://[^"]*')
curl -LO "$DEB_URL"
dpkg -i ocicl_*_amd64.deb
ocicl setup > ~/.sbclrc
```

## Test plan
- [ ] Verify the sandbox container builds successfully
- [ ] Verify a package build (e.g., trivial-mimes) works end-to-end with the .deb-installed ocicl

🤖 Generated with [Claude Code](https://claude.com/claude-code)